### PR TITLE
Don't cut tweets with >140 symbols

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "express": "^4.12.4",
     "file-type": "^3.1.0",
     "fs-extra": "^0.26.0",
-    "get-tweets": "^3.0.0",
+    "@xamgore/get-tweets": "^4.1.0",
     "get-twitter-followers": "^1.1.0",
     "get-twitter-info": "^1.0.5",
     "got": "^5.0.0",


### PR DESCRIPTION
The problem is in the `getTweets` package, it uses an old API version, so tweets are loaded in shortened form: on september 2017, twitter extended the maximum amount of characters per tweet (from 140 to 270). I modified the original package, published to npm, and here it is.