### PR TITLE
fix #4 tweet text trimmed on 115 characters

### DIFF
--- a/authors.js
+++ b/authors.js
@@ -1,4 +1,6 @@
-export default [
+import authorId from './helpers/author-id';
+
+export default authorId([
   // { username: 'twitter_name', start: '15 feb 2019', first: '640816652293144576', post: false },
   //{ username: 'sam_dark',        start: '07 jan 2019', first: '1082232094607183872', post: false },
   // { username: 'musuk',           start: '24 dec 2018', first: '1077109862444777472' },
@@ -136,4 +138,4 @@ export default [
   { username: '4gophers',        start: '13 jul 2015', first: '620509320183050240' },
   { username: 'zkonstantin',     start: '06 jul 2015', first: '617783792443486208' },
   { username: 'nmishin',         start: '29 jun 2015', first: '615292664888561664' },
-];
+]);

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -124,7 +124,7 @@ task('rss', done => {
     feed.item({
       title: author.username,
       description: render(firstTweet(author)),
-      url: `https://jsunderhood.ru/${author.authorId}/`,
+      url: `https://backendsecret.ru/${author.authorId}/`,
       date: firstTweet(author).created_at,
     });
   });

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "express": "^4.12.4",
     "file-type": "^3.1.0",
     "fs-extra": "^0.26.0",
-    "get-tweets": "^3.0.0",
     "get-twitter-followers": "^1.1.0",
     "get-twitter-info": "^1.0.5",
     "got": "^5.0.0",

--- a/roadmap.md
+++ b/roadmap.md
@@ -1,1 +1,0 @@
-See generator-underhood’s [ROADMAP](https://github.com/iamstarkov/generator-underhood/blob/master/ROADMAP.md).

--- a/test.js
+++ b/test.js
@@ -17,19 +17,15 @@ import getDiffFollowers from './helpers/get-diff-followers';
 
 describe('js', () => {
   it('getGainedFollowers ordinary', () => {
-    assert.equal(getGainedFollowers('rstacruz'), 17);
+    assert.equal(getGainedFollowers('dsimonov'), 5240);
   });
   it('getGainedFollowers first one', () => {
-    assert.equal(getGainedFollowers('shuvalov_anton'), 115);
+    assert.equal(getGainedFollowers('nmishin'), 109);
   });
   it('getDiffFollowers normal', () => {
-    assert.deepEqual(getDiffFollowers('rstacruz'), { gain: 29, loss: 12 });
-    assert.deepEqual(getDiffFollowers('touzoku'), { gain: 88, loss: 15 });
-    assert.deepEqual(getDiffFollowers('milk_is_my_life'), { gain: 60, loss: 28 });
-  });
-  it('getDiffFollowers obsolete', () => {
-    assert.equal(getDiffFollowers('ihorzenich'), undefined);
-    assert.equal(getDiffFollowers('oleg008'), undefined);
+    assert.deepEqual(getDiffFollowers('_bravit'), { gain: 234, loss: 84 });
+    assert.deepEqual(getDiffFollowers('yegor256'), { gain: 558, loss: 234 });
+    assert.deepEqual(getDiffFollowers('JFrog'), { gain: 223, loss: 34 });
   });
 });
 


### PR DESCRIPTION
Hi!
* I've fixed tweet length problem 
* statistics generation and stats gulp task
* repo has roadmap.md and ROADMAP.md files that leads to problem on case insensitive fs's

I've compared with the latest abroadunderhood code and find that it uses own local version 
get-tweets not from package (that archived) with option   tweet_mode: 'extended'.

I don't have a twitter application token now (pending status). And it will be nice,
if somebody can check.

We should create an another tool (like update.js) that re-downloads tweet texts from dump folder based on tweet "id"